### PR TITLE
Add patch for l2cap.c from bluepad32

### DIFF
--- a/development/software/src/components/btstack/src/l2cap.c
+++ b/development/software/src/components/btstack/src/l2cap.c
@@ -2457,7 +2457,7 @@ static void l2cap_handle_remote_supported_features_received(l2cap_channel_t * ch
 
         // incoming: assert security requirements
         channel->state = L2CAP_STATE_WAIT_INCOMING_SECURITY_LEVEL_UPDATE;
-        if (channel->required_security_level <= gap_security_level(channel->con_handle)){
+        if (1) {
             l2cap_handle_security_level_incoming_sufficient(channel);
         } else {
             // send connection pending if not already done


### PR DESCRIPTION
This enables e.g. pairing a DualShock 3 controller.

See https://github.com/ricardoquesada/bluepad32/blob/main/external/patches/0002-l2cap-allow-incoming-connection-with-not-enough.patch